### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/PyBGL/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/PyBGL/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -87,3 +87,8 @@ To build ``.deb`` package (in ``deb_dist/``), run:
 
   python3 setup.py --command-packages=stdeb.command bdist_deb
 
+=======
+License
+=======
+
+This project is licensed under the BSD-3-Clause license - see the `LICENSE <https://github.com/nokia/PyBGL/blob/master/LICENSE>`_.


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.